### PR TITLE
Determine and display correct twitter link preview

### DIFF
--- a/components/domain/sections/seo-section.test.tsx
+++ b/components/domain/sections/seo-section.test.tsx
@@ -123,6 +123,7 @@ describe("SeoSection", () => {
         description: "Preview Description",
         image: "https://example.com/preview.png",
         canonicalUrl: "https://example.com/",
+        twitterCardVariant: "large",
       },
       timestamps: { fetchedAt: "2024-01-01T00:00:00.000Z" },
       source: { finalUrl: "https://example.com/page", status: 200 },

--- a/components/domain/sections/seo-section.tsx
+++ b/components/domain/sections/seo-section.tsx
@@ -63,6 +63,7 @@ type SeoResponse = {
     description: string | null;
     image: string | null;
     canonicalUrl: string;
+    twitterCardVariant: "compact" | "large";
   } | null;
   timestamps: { fetchedAt: string };
   source: { finalUrl: string | null; status: number | null };
@@ -203,15 +204,7 @@ export function SeoSection({
                       description={data.preview.description ?? "No description"}
                       image={data.preview.image}
                       url={data.preview.canonicalUrl}
-                      variant="large"
-                    />
-                    <SocialPreview
-                      provider="x"
-                      title={data.preview.title ?? "No title"}
-                      description={data.preview.description ?? "No description"}
-                      image={data.preview.image}
-                      url={data.preview.canonicalUrl}
-                      variant="compact"
+                      variant={data.preview.twitterCardVariant}
                     />
                   </div>
                 ) : null}

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -50,6 +50,7 @@ export type SeoPreview = {
   description: string | null;
   image: string | null;
   canonicalUrl: string;
+  twitterCardVariant: "compact" | "large";
 };
 
 export function sanitizeText(input: unknown): string {
@@ -170,7 +171,14 @@ export function selectPreview(
   const image = meta?.openGraph.images?.[0] || meta?.twitter.image || null;
   const canonicalUrl =
     meta?.general.canonical || meta?.openGraph.url || finalUrl;
-  return { title, description, image, canonicalUrl };
+  const twitterCardRaw = meta?.twitter.card?.toLowerCase().trim() ?? "";
+  const twitterCardNormalized = twitterCardRaw.replace(/\s+/g, "_");
+  const twitterCardVariant: "compact" | "large" =
+    twitterCardNormalized === "summary_large_image" ||
+    twitterCardNormalized === "player"
+      ? "large"
+      : "compact";
+  return { title, description, image, canonicalUrl, twitterCardVariant };
 }
 
 export function parseRobotsTxt(text: string): RobotsTxt {


### PR DESCRIPTION
Show only one Twitter link preview card by determining the correct variant on the backend.

---
<a href="https://cursor.com/background-agent?bcId=bc-646a2049-3ca6-4b97-8078-5f432c6b6a31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-646a2049-3ca6-4b97-8078-5f432c6b6a31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

