### PR TITLE
fix: optimize stale domain cleanup N+1 delete pattern

### DIFF
--- a/apps/web/app/api/cron/cleanup-stale-domains/route.ts
+++ b/apps/web/app/api/cron/cleanup-stale-domains/route.ts
@@ -1,16 +1,13 @@
 import { subDays } from "date-fns";
 import { NextResponse } from "next/server";
 
-import { deleteStaleUnverifiedDomains, getStaleUnverifiedDomains } from "@domainstack/db/queries";
+import { deleteStaleUnverifiedDomainsByCutoff } from "@domainstack/db/queries";
 import { createLogger } from "@domainstack/logger";
 
 const logger = createLogger({ source: "cron/cleanup-stale-domains" });
 
 // Domains that remain unverified after this many days will be deleted
 const STALE_DOMAIN_DAYS = 30;
-
-// Maximum number of IDs to delete in a single batch to avoid huge IN clauses
-const DELETE_BATCH_SIZE = 500;
 
 /**
  * Cron job to clean up stale unverified domains.
@@ -29,9 +26,11 @@ export async function GET(request: Request) {
     logger.info("Starting cleanup stale domains cron job");
 
     const cutoffDate = subDays(new Date(), STALE_DOMAIN_DAYS);
-    const staleDomains = await getStaleUnverifiedDomains(cutoffDate);
 
-    if (staleDomains.length === 0) {
+    // Optimized: Delete directly by cutoff date in a single query
+    const deletedCount = await deleteStaleUnverifiedDomainsByCutoff(cutoffDate);
+
+    if (deletedCount === 0) {
       logger.info("No stale domains to cleanup");
       return NextResponse.json({
         total: 0,
@@ -40,23 +39,10 @@ export async function GET(request: Request) {
       });
     }
 
-    const ids = staleDomains.map((d) => d.id);
-
-    // Delete in batches to avoid huge IN clauses
-    let deletedCount = 0;
-    for (let i = 0; i < ids.length; i += DELETE_BATCH_SIZE) {
-      const batch = ids.slice(i, i + DELETE_BATCH_SIZE);
-      const batchDeleted = await deleteStaleUnverifiedDomains(batch);
-      deletedCount += batchDeleted;
-    }
-
-    logger.info(
-      { total: staleDomains.length, deleted: deletedCount },
-      "Cleanup stale domains completed",
-    );
+    logger.info({ deleted: deletedCount }, "Cleanup stale domains completed");
 
     return NextResponse.json({
-      total: staleDomains.length,
+      total: deletedCount,
       deleted: deletedCount,
       cutoffDate: cutoffDate.toISOString(),
     });

--- a/packages/db/src/queries/tracked-domains.ts
+++ b/packages/db/src/queries/tracked-domains.ts
@@ -1177,3 +1177,21 @@ export async function deleteStaleUnverifiedDomains(ids: string[]): Promise<numbe
 
   return deleted.length;
 }
+
+/**
+ * Delete stale unverified domains directly by cutoff date in a single query.
+ * Optimized to avoid N+1 select-then-delete pattern.
+ *
+ * @param cutoffDate - Domains created before this date that are unverified will be deleted
+ * @returns Number of domains deleted
+ */
+export async function deleteStaleUnverifiedDomainsByCutoff(cutoffDate: Date): Promise<number> {
+  const deleted = await db
+    .delete(userTrackedDomains)
+    .where(
+      and(eq(userTrackedDomains.verified, false), lt(userTrackedDomains.createdAt, cutoffDate)),
+    )
+    .returning({ id: userTrackedDomains.id });
+
+  return deleted.length;
+}

--- a/packages/db/src/queries/tracked-domains.ts
+++ b/packages/db/src/queries/tracked-domains.ts
@@ -1186,12 +1186,11 @@ export async function deleteStaleUnverifiedDomains(ids: string[]): Promise<numbe
  * @returns Number of domains deleted
  */
 export async function deleteStaleUnverifiedDomainsByCutoff(cutoffDate: Date): Promise<number> {
-  const deleted = await db
+  const result = await db
     .delete(userTrackedDomains)
     .where(
       and(eq(userTrackedDomains.verified, false), lt(userTrackedDomains.createdAt, cutoffDate)),
-    )
-    .returning({ id: userTrackedDomains.id });
+    );
 
-  return deleted.length;
+  return result.rowCount;
 }


### PR DESCRIPTION
This PR optimizes the stale domain cleanup cron job by eliminating an N+1 database pattern.

💡 **What:**
The cleanup logic previously performed a `SELECT` to fetch all stale domain IDs, and then performed multiple `DELETE` operations in batches of 500. This has been replaced by a single `DELETE` statement that uses the same filtering criteria (`verified = false` and `createdAt < cutoffDate`) directly in the database.

🎯 **Why:**
The previous pattern caused unnecessary database round-trips and increased application memory usage by fetching all stale domain records into memory before deleting them.

📊 **Measured Improvement:**
- **Database Round-trips:** Reduced from $1 + N/500$ to exactly $1$.
- **Benchmark Results (1200 domains):**
  - Baseline: 4 round-trips (1 SELECT + 3 batch DELETEs)
  - Optimized: 1 round-trip
  - **Improvement:** 75% reduction in round-trips for this data set.
- Efficiency gains increase linearly with the number of stale domains.

---
*PR created automatically by Jules for task [18249555057200548259](https://jules.google.com/task/18249555057200548259) started by @jakejarvis*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimize stale domain cleanup by replacing the fetch-and-batch delete with a single SQL DELETE using a cutoff date. This reduces DB round-trips to 1 and avoids fetching deleted IDs by using `rowCount`.

- **Refactors**
  - Added `deleteStaleUnverifiedDomainsByCutoff` in `@domainstack/db/queries` that returns `rowCount`.
  - Updated cleanup cron route to call it and return the deleted count.
  - Removed batch delete logic, constants, and the unused `getStaleUnverifiedDomains` import; simplified logging.

<sup>Written for commit 164539f27d842cbaacc5f06378357bdbe9521971. Summary will update on new commits. <a href="https://cubic.dev/pr/jakejarvis/domainstack.io/pull/449?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

