### PR TITLE
fix: potential null return in deleteStaleUnverifiedDomainsByCutoff

### DIFF
--- a/packages/db/src/queries/tracked-domains.ts
+++ b/packages/db/src/queries/tracked-domains.ts
@@ -1192,5 +1192,5 @@ export async function deleteStaleUnverifiedDomainsByCutoff(cutoffDate: Date): Pr
       and(eq(userTrackedDomains.verified, false), lt(userTrackedDomains.createdAt, cutoffDate)),
     );
 
-  return result.rowCount;
+  return result.rowCount ?? 0;
 }


### PR DESCRIPTION
## Summary
Add null coalescing operator to ensure `deleteStaleUnverifiedDomainsByCutoff` always returns a number instead of potentially returning `null`.

## Changes
- Updated return statement in `deleteStaleUnverifiedDomainsByCutoff` to use null coalescing (`??`) operator, defaulting to `0` when `result.rowCount` is null

## Details
The database query result's `rowCount` property can be `null` in some cases. This change ensures the function always returns a valid number (either the actual row count or `0`), improving type safety and preventing potential issues for callers expecting a numeric return value.

https://claude.ai/code/session_01SZj5CYMSH9LESfUaPazv8s

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always return a number from deleteStaleUnverifiedDomainsByCutoff by defaulting rowCount to 0 when it’s null. Prevents type errors and keeps the function’s Promise<number> contract.

<sup>Written for commit 392c0bee904b130e8b09f06dfb9dff309617e0d7. Summary will update on new commits. <a href="https://cubic.dev/pr/jakejarvis/domainstack.io/pull/452?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

